### PR TITLE
feat: Enhance try_rename_with_candidates and improve download logging accuracy

### DIFF
--- a/radiko_timeshift_recorder/download.py
+++ b/radiko_timeshift_recorder/download.py
@@ -104,9 +104,11 @@ async def download(job: Job, out_dir: Path) -> None:
         for filename in filename_candidates
     ]
 
-    for out_filepath in out_filepath_candidates:
-        if out_filepath.exists():
-            logger.info(f"File {out_filepath} already exists. Skipping download.")
+    for filepath_to_check_existence in out_filepath_candidates:
+        if filepath_to_check_existence.exists():
+            logger.info(
+                f"File {filepath_to_check_existence} already exists. Skipping download."
+            )
             return
 
     program_dir.mkdir(parents=True, exist_ok=True)

--- a/radiko_timeshift_recorder/download.py
+++ b/radiko_timeshift_recorder/download.py
@@ -66,6 +66,9 @@ async def download_stream(url: str, out_filepath: Path) -> None:
 def try_rename_with_candidates(
     temp_filepath: Path, out_filepath_candidates: list[Path]
 ) -> Path:
+    if not out_filepath_candidates:
+        raise ValueError("out_filepath_candidates list cannot be empty.")
+
     name_too_long_exception: Optional[OSError] = None
     for out_filepath_candidate in out_filepath_candidates:
         try:

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -104,9 +104,10 @@ def test_try_rename_with_candidates_success_first_try(mocker: MockerFixture) -> 
     ]
     mock_replace = mocker.patch.object(Path, "replace")
 
-    try_rename_with_candidates(temp_filepath, out_filepath_candidates)
+    returned_path = try_rename_with_candidates(temp_filepath, out_filepath_candidates)
 
     mock_replace.assert_called_once_with(out_filepath_candidates[0])
+    assert returned_path == out_filepath_candidates[0]
 
 
 def test_try_rename_with_candidates_success_second_try(mocker: MockerFixture) -> None:
@@ -122,7 +123,7 @@ def test_try_rename_with_candidates_success_second_try(mocker: MockerFixture) ->
         None,  # Second call succeeds
     ]
 
-    try_rename_with_candidates(temp_filepath, out_filepath_candidates)
+    returned_path = try_rename_with_candidates(temp_filepath, out_filepath_candidates)
 
     assert mock_replace.call_count == 2
     mock_replace.assert_has_calls(
@@ -131,6 +132,7 @@ def test_try_rename_with_candidates_success_second_try(mocker: MockerFixture) ->
             mocker.call(out_filepath_candidates[1]),
         ]
     )
+    assert returned_path == out_filepath_candidates[1]
 
 
 def test_try_rename_with_candidates_fail_all_name_too_long(

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -152,6 +152,16 @@ def test_try_rename_with_candidates_fail_all_name_too_long(
     mock_replace.assert_has_calls([mocker.call(p) for p in out_filepath_candidates])
 
 
+def test_try_rename_with_candidates_empty_list() -> None:
+    """Test case where the list of output filepath candidates is empty."""
+    temp_filepath = Path("/tmp/tempfile")
+
+    with pytest.raises(
+        ValueError, match="out_filepath_candidates list cannot be empty"
+    ):
+        try_rename_with_candidates(temp_filepath, [])
+
+
 def test_try_rename_with_candidates_fail_other_oserror(mocker: MockerFixture) -> None:
     """Test case where an OSError other than ENAMETOOLONG occurs."""
     temp_filepath = Path("/tmp/tempfile")


### PR DESCRIPTION
- **feat(download): Make try_rename_with_candidates return the renamed path**
- **feat(download): Raise ValueError for empty candidates in rename util**
- **refactor(download): Clarify variable name in pre-existence check loop**
