### PR TITLE
feat(cli): Add --log-json option for JSON formatted logging

### DIFF
--- a/radiko_timeshift_recorder/__main__.py
+++ b/radiko_timeshift_recorder/__main__.py
@@ -1,4 +1,8 @@
+from typing import Annotated
+
+import logzero
 import typer
+from logzero import logger
 
 from radiko_timeshift_recorder.commands.gen_json_schema_for_rules import (
     app as gen_json_schema_for_rules_app,
@@ -12,6 +16,23 @@ from radiko_timeshift_recorder.commands.put_jobs_from_schedule_by_rules import (
 from radiko_timeshift_recorder.commands.run_server import app as run_server_app
 
 app = typer.Typer()
+
+
+@app.callback()
+def main(
+    log_json: Annotated[
+        bool,
+        typer.Option(
+            help="Output logs in JSON format.",
+            is_flag=True,
+        ),
+    ] = False,
+) -> None:
+    if log_json:
+        logzero.json(enable=True)
+        logger.info("JSON logging enabled.")
+
+
 app.add_typer(gen_json_schema_for_rules_app)
 app.add_typer(put_job_from_url_app)
 app.add_typer(put_jobs_from_schedule_by_rules_app)


### PR DESCRIPTION
Introduce a new command-line option `--log-json` that enables
JSON formatted output for all application logs.

When this flag is provided, `logzero`'s JSON logging capability
is activated. This facilitates easier log parsing, aggregation,
and integration with external log management systems.
