### PR TITLE
ci(dependabot): group minor and patch updates into single PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,25 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     reviewers:
       - dmingn
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     reviewers:
       - dmingn


### PR DESCRIPTION
Add groups.minor-and-patch for github-actions and pip (patterns *, update-types minor/patch) so weekly bumps are batched per ecosystem.

Major version updates remain outside this group and keep separate PRs.

Made-with: Cursor
