### PR TITLE
feat(server): add configurable output modes and optional chgrp

### DIFF
--- a/radiko_timeshift_recorder/commands/run_server.py
+++ b/radiko_timeshift_recorder/commands/run_server.py
@@ -1,11 +1,16 @@
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Optional
 
 import typer
 import uvicorn
 from logzero import logger
 
-from radiko_timeshift_recorder.download import download
+from radiko_timeshift_recorder.download import (
+    DEFAULT_OUTPUT_DIR_MODE,
+    DEFAULT_OUTPUT_FILE_MODE,
+    download,
+)
+from radiko_timeshift_recorder.fs_unix import parse_unix_mode_string
 from radiko_timeshift_recorder.server import app as fastapi_app
 
 app = typer.Typer()
@@ -28,9 +33,47 @@ def run_server(
     num_workers: Annotated[
         int, typer.Option(min=1, help="Number of workers to run")
     ] = 3,
+    output_file_mode: Annotated[
+        str,
+        typer.Option(
+            help=(
+                "Octal permission bits for recorded .mp4 files after download "
+                f"(e.g. 644 or 0644). Default: {DEFAULT_OUTPUT_FILE_MODE:o}."
+            ),
+        ),
+    ] = "644",
+    output_dir_mode: Annotated[
+        str,
+        typer.Option(
+            help=(
+                "Octal permission bits for directories created under --out-dir "
+                f"(e.g. 755, 2775 for setgid). Subject to process umask like mkdir(2). "
+                f"Default: {DEFAULT_OUTPUT_DIR_MODE:o}."
+            ),
+        ),
+    ] = "755",
+    output_gid: Annotated[
+        Optional[int],
+        typer.Option(
+            help=(
+                "Numeric group ID for output files and for directories under --out-dir "
+                "(each segment from the first subdirectory through the program folder; "
+                "--out-dir itself is not changed). The process must be allowed to chown "
+                "to this group (e.g. set Docker user / group_add accordingly). Unix only."
+            ),
+        ),
+    ] = None,
 ):
     try:
-        fastapi_app.state.process_job = lambda job: download(job=job, out_dir=out_dir)
+        file_mode = parse_unix_mode_string(output_file_mode)
+        dir_mode = parse_unix_mode_string(output_dir_mode)
+        fastapi_app.state.process_job = lambda job: download(
+            job=job,
+            out_dir=out_dir,
+            output_file_mode=file_mode,
+            output_dir_mode=dir_mode,
+            output_gid=output_gid,
+        )
         fastapi_app.state.num_workers = num_workers
         uvicorn.run(app=fastapi_app, host=host, port=port)
     except Exception:

--- a/radiko_timeshift_recorder/download.py
+++ b/radiko_timeshift_recorder/download.py
@@ -1,6 +1,7 @@
 import asyncio
 import errno
 import logging
+import os
 import shlex
 import tempfile
 from pathlib import Path
@@ -9,9 +10,13 @@ from typing import Optional
 import tenacity
 from logzero import logger
 
+from radiko_timeshift_recorder.fs_unix import chown_group_under_ancestor
 from radiko_timeshift_recorder.get_duration import get_duration
 from radiko_timeshift_recorder.job import Job
 from radiko_timeshift_recorder.radiko import Program
+
+DEFAULT_OUTPUT_FILE_MODE = 0o644
+DEFAULT_OUTPUT_DIR_MODE = 0o755
 
 
 def generate_filename_candidates(program: Program) -> tuple[str, ...]:
@@ -94,7 +99,14 @@ def try_rename_with_candidates(
     wait=tenacity.wait_fixed(wait=60),
     before_sleep=tenacity.before_sleep_log(logger=logger, log_level=logging.INFO),
 )
-async def download(job: Job, out_dir: Path) -> None:
+async def download(
+    job: Job,
+    out_dir: Path,
+    *,
+    output_file_mode: int = DEFAULT_OUTPUT_FILE_MODE,
+    output_dir_mode: int = DEFAULT_OUTPUT_DIR_MODE,
+    output_gid: Optional[int] = None,
+) -> None:
     program_dir = out_dir / job.station_id / job.program.title
     filename_candidates = generate_filename_candidates(job.program)
     suffix = ".mp4"
@@ -111,7 +123,7 @@ async def download(job: Job, out_dir: Path) -> None:
             )
             return
 
-    program_dir.mkdir(parents=True, exist_ok=True)
+    program_dir.mkdir(parents=True, exist_ok=True, mode=output_dir_mode)
 
     with tempfile.NamedTemporaryFile(
         mode="w+b",
@@ -133,5 +145,9 @@ async def download(job: Job, out_dir: Path) -> None:
         out_filepath = try_rename_with_candidates(
             temp_filepath, out_filepath_candidates
         )
+
+    os.chmod(out_filepath, output_file_mode)
+    if output_gid is not None:
+        chown_group_under_ancestor(out_dir, out_filepath, output_gid)
 
     logger.info(f"Downloaded {job} to {out_filepath}")

--- a/radiko_timeshift_recorder/fs_unix.py
+++ b/radiko_timeshift_recorder/fs_unix.py
@@ -1,0 +1,52 @@
+"""Unix filesystem helpers."""
+
+import os
+from pathlib import Path
+
+# Permission + setuid/setgid/sticky bits (12 bits), as accepted by chmod(2) on Unix.
+_MAX_MODE = 0o7777
+
+
+def parse_unix_mode_string(value: str) -> int:
+    """
+    Parse a non-empty string of octal digits (e.g. ``644``, ``0755``, ``2775``).
+
+    Rejects values above ``0o7777`` (e.g. ``77777``) so only the usual chmod
+    bit range is accepted.
+    """
+    v = value.strip()
+    if not v:
+        raise ValueError("Mode string is empty.")
+    if not all(c in "01234567" for c in v):
+        raise ValueError(
+            f"Mode must be octal digits only (e.g. 644 or 0755), got {value!r}"
+        )
+    mode = int(v, 8)
+    if mode > _MAX_MODE:
+        raise ValueError(
+            f"Mode must be at most {_MAX_MODE:o} (12 permission bits), got {value!r}"
+        )
+    return mode
+
+
+def chown_group_under_ancestor(ancestor: Path, path: Path, gid: int) -> None:
+    """
+    Set group ``gid`` on ``path`` and on each directory strictly between ``ancestor`` and ``path``.
+
+    ``ancestor`` itself is not modified. Directories from the first segment under ``ancestor``
+    through ``path``'s parent are updated, then ``path``.
+
+    ``path`` must resolve under ``ancestor``; otherwise raises ``ValueError``.
+    """
+    parent = path.parent
+    try:
+        rel = parent.resolve().relative_to(ancestor.resolve())
+    except ValueError as e:
+        raise ValueError(
+            f"path must be under ancestor (path={path!r}, ancestor={ancestor!r})"
+        ) from e
+    current = ancestor
+    for part in rel.parts:
+        current = current / part
+        os.chown(current, -1, gid)
+    os.chown(path, -1, gid)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,5 +1,6 @@
 import datetime
 import errno
+import stat
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
@@ -7,9 +8,11 @@ import pytest
 from pytest_mock import MockerFixture
 
 from radiko_timeshift_recorder.download import (
+    download,
     generate_filename_candidates,
     try_rename_with_candidates,
 )
+from radiko_timeshift_recorder.job import Job
 from radiko_timeshift_recorder.radiko import Program
 
 
@@ -93,6 +96,87 @@ def test_generate_filename_candidates(
     )
 
     assert generate_filename_candidates(program) == expected_candidates
+
+
+@pytest.mark.asyncio
+async def test_download_applies_file_and_dir_modes(
+    tmp_path: Path, mocker: MockerFixture, sample_job: Job
+) -> None:
+    out = tmp_path / "out"
+    out.mkdir()
+
+    async def fake_download_stream(url: str, fp: Path) -> None:
+        fp.write_bytes(b"x")
+
+    mocker.patch(
+        "radiko_timeshift_recorder.download.download_stream",
+        side_effect=fake_download_stream,
+    )
+    mocker.patch(
+        "radiko_timeshift_recorder.download.get_duration",
+        return_value=900.0,
+    )
+
+    ref_dir = tmp_path / "umask_ref"
+    ref_dir.mkdir(mode=0o750)
+    expected_dir_mode = stat.S_IMODE(ref_dir.stat().st_mode)
+
+    await download(
+        sample_job,
+        out,
+        output_file_mode=0o640,
+        output_dir_mode=0o750,
+        output_gid=None,
+    )
+
+    mp4s = list(out.rglob("*.mp4"))
+    assert len(mp4s) == 1
+    assert stat.S_IMODE(mp4s[0].stat().st_mode) == 0o640
+
+    program_dir = out / "TEST" / "test program"
+    assert program_dir.is_dir()
+    assert stat.S_IMODE(program_dir.stat().st_mode) == expected_dir_mode
+
+
+@pytest.mark.asyncio
+async def test_download_chowns_when_output_gid(
+    tmp_path: Path, mocker: MockerFixture, sample_job: Job
+) -> None:
+    out = tmp_path / "out"
+    out.mkdir()
+    gid = 12345
+
+    async def fake_download_stream(url: str, fp: Path) -> None:
+        fp.write_bytes(b"x")
+
+    mocker.patch(
+        "radiko_timeshift_recorder.download.download_stream",
+        side_effect=fake_download_stream,
+    )
+    mocker.patch(
+        "radiko_timeshift_recorder.download.get_duration",
+        return_value=900.0,
+    )
+    mock_chown = mocker.patch("radiko_timeshift_recorder.fs_unix.os.chown")
+
+    await download(
+        sample_job,
+        out,
+        output_file_mode=0o644,
+        output_dir_mode=0o755,
+        output_gid=gid,
+    )
+
+    mp4 = next(out.rglob("*.mp4"))
+    station_dir = out / "TEST"
+    program_dir = out / "TEST" / "test program"
+    chown_targets = {Path(c.args[0]).resolve() for c in mock_chown.call_args_list}
+    assert station_dir.resolve() in chown_targets
+    assert program_dir.resolve() in chown_targets
+    assert mp4.resolve() in chown_targets
+    for call in mock_chown.call_args_list:
+        assert call.args[1] == -1
+        assert call.args[2] == gid
 
 
 def test_try_rename_with_candidates_success_first_try(mocker: MockerFixture) -> None:

--- a/tests/test_fs_unix.py
+++ b/tests/test_fs_unix.py
@@ -1,0 +1,83 @@
+from pathlib import Path
+
+import pytest
+from pytest_mock import MockerFixture
+
+from radiko_timeshift_recorder.fs_unix import (
+    chown_group_under_ancestor,
+    parse_unix_mode_string,
+)
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("644", 0o644),
+        ("0644", 0o644),
+        ("755", 0o755),
+        ("2775", 0o2775),
+        ("7777", 0o7777),
+    ],
+)
+def test_parse_unix_mode_string(text: str, expected: int) -> None:
+    assert parse_unix_mode_string(text) == expected
+
+
+def test_parse_unix_mode_string_rejects_python_literal() -> None:
+    with pytest.raises(ValueError, match="octal digits"):
+        parse_unix_mode_string("0o644")
+
+
+@pytest.mark.parametrize("too_large", ["77777", "100000", "777777"])
+def test_parse_unix_mode_string_rejects_too_many_bits(too_large: str) -> None:
+    with pytest.raises(ValueError, match="12 permission bits"):
+        parse_unix_mode_string(too_large)
+
+
+def test_chown_group_under_ancestor_chowns_each_segment_and_file(
+    tmp_path: Path, mocker: MockerFixture
+) -> None:
+    ancestor = tmp_path / "out"
+    station = ancestor / "TEST"
+    program_dir = station / "title"
+    file_path = program_dir / "rec.mp4"
+    program_dir.mkdir(parents=True)
+    file_path.write_text("x")
+    gid = 12345
+
+    mock_chown = mocker.patch("radiko_timeshift_recorder.fs_unix.os.chown")
+    chown_group_under_ancestor(ancestor, file_path, gid)
+
+    chowned = {Path(c.args[0]).resolve() for c in mock_chown.call_args_list}
+    assert chowned == {station.resolve(), program_dir.resolve(), file_path.resolve()}
+    for call in mock_chown.call_args_list:
+        assert call.args[1] == -1
+        assert call.args[2] == gid
+
+
+def test_chown_group_under_ancestor_only_file_when_directly_under_ancestor(
+    tmp_path: Path, mocker: MockerFixture
+) -> None:
+    ancestor = tmp_path / "out"
+    ancestor.mkdir()
+    file_path = ancestor / "x.mp4"
+    file_path.write_text("x")
+    mock_chown = mocker.patch("radiko_timeshift_recorder.fs_unix.os.chown")
+
+    chown_group_under_ancestor(ancestor, file_path, 99)
+
+    assert len(mock_chown.call_args_list) == 1
+    assert Path(mock_chown.call_args_list[0].args[0]).resolve() == file_path.resolve()
+
+
+def test_chown_group_under_ancestor_rejects_path_not_under_ancestor(
+    tmp_path: Path,
+) -> None:
+    ancestor = tmp_path / "a"
+    ancestor.mkdir()
+    outside = tmp_path / "b" / "f.txt"
+    outside.parent.mkdir()
+    outside.write_text("x")
+
+    with pytest.raises(ValueError, match="path must be under ancestor"):
+        chown_group_under_ancestor(ancestor, outside, 1)


### PR DESCRIPTION
Add radiko_timeshift_recorder/fs_unix.py with parse_unix_mode_string for chmod-style octal strings and chown_group_under_ancestor to apply a numeric GID to each path segment under a root directory plus the target file.

Extend run-server with --output-file-mode, --output-dir-mode, and optional --output-gid; pass parsed values into download().

download() uses output_dir_mode for mkdir(parents=True), then after a successful rename applies os.chmod to the .mp4 and optionally chowns from the first subdirectory under out_dir through the file when output_gid is set.

Add tests for fs_unix and for download (umask-adjusted dir mode, chmod, and chown call targets).

Made-with: Cursor
