### PR TITLE
feat: add configurable output file mode for recordings

### DIFF
--- a/radiko_timeshift_recorder/commands/run_server.py
+++ b/radiko_timeshift_recorder/commands/run_server.py
@@ -5,7 +5,8 @@ import typer
 import uvicorn
 from logzero import logger
 
-from radiko_timeshift_recorder.download import download
+from radiko_timeshift_recorder.download import DEFAULT_OUTPUT_FILE_MODE, download
+from radiko_timeshift_recorder.fs_unix import parse_unix_mode_string
 from radiko_timeshift_recorder.server import app as fastapi_app
 
 app = typer.Typer()
@@ -28,9 +29,23 @@ def run_server(
     num_workers: Annotated[
         int, typer.Option(min=1, help="Number of workers to run")
     ] = 3,
+    output_file_mode: Annotated[
+        str,
+        typer.Option(
+            help=(
+                "Octal permission bits for recorded .mp4 files after download "
+                f"(e.g. 644 or 0644). Default: {DEFAULT_OUTPUT_FILE_MODE:o}."
+            ),
+        ),
+    ] = "644",
 ):
     try:
-        fastapi_app.state.process_job = lambda job: download(job=job, out_dir=out_dir)
+        file_mode = parse_unix_mode_string(output_file_mode)
+        fastapi_app.state.process_job = lambda job: download(
+            job=job,
+            out_dir=out_dir,
+            output_file_mode=file_mode,
+        )
         fastapi_app.state.num_workers = num_workers
         uvicorn.run(app=fastapi_app, host=host, port=port)
     except Exception:

--- a/radiko_timeshift_recorder/download.py
+++ b/radiko_timeshift_recorder/download.py
@@ -1,6 +1,7 @@
 import asyncio
 import errno
 import logging
+import os
 import shlex
 import tempfile
 from pathlib import Path
@@ -12,6 +13,8 @@ from logzero import logger
 from radiko_timeshift_recorder.get_duration import get_duration
 from radiko_timeshift_recorder.job import Job
 from radiko_timeshift_recorder.radiko import Program
+
+DEFAULT_OUTPUT_FILE_MODE = 0o644
 
 
 def generate_filename_candidates(program: Program) -> tuple[str, ...]:
@@ -94,7 +97,12 @@ def try_rename_with_candidates(
     wait=tenacity.wait_fixed(wait=60),
     before_sleep=tenacity.before_sleep_log(logger=logger, log_level=logging.INFO),
 )
-async def download(job: Job, out_dir: Path) -> None:
+async def download(
+    job: Job,
+    out_dir: Path,
+    *,
+    output_file_mode: int = DEFAULT_OUTPUT_FILE_MODE,
+) -> None:
     program_dir = out_dir / job.station_id / job.program.title
     filename_candidates = generate_filename_candidates(job.program)
     suffix = ".mp4"
@@ -134,4 +142,5 @@ async def download(job: Job, out_dir: Path) -> None:
             temp_filepath, out_filepath_candidates
         )
 
+    os.chmod(out_filepath, output_file_mode)
     logger.info(f"Downloaded {job} to {out_filepath}")

--- a/radiko_timeshift_recorder/download.py
+++ b/radiko_timeshift_recorder/download.py
@@ -101,7 +101,7 @@ async def _download_and_validate_stream(job: Job, temp_filepath: Path) -> None:
     await download_stream(job.url, temp_filepath)
     recorded_dur = await get_duration(temp_filepath)
     if abs(recorded_dur - job.program.dur) > 1:
-        raise AssertionError(
+        raise RuntimeError(
             f"Recorded duration {recorded_dur} differs from the program duration {job.program.dur}."
         )
 

--- a/radiko_timeshift_recorder/download.py
+++ b/radiko_timeshift_recorder/download.py
@@ -97,6 +97,15 @@ def try_rename_with_candidates(
     wait=tenacity.wait_fixed(wait=60),
     before_sleep=tenacity.before_sleep_log(logger=logger, log_level=logging.INFO),
 )
+async def _download_and_validate_stream(job: Job, temp_filepath: Path) -> None:
+    await download_stream(job.url, temp_filepath)
+    recorded_dur = await get_duration(temp_filepath)
+    if abs(recorded_dur - job.program.dur) > 1:
+        raise AssertionError(
+            f"Recorded duration {recorded_dur} differs from the program duration {job.program.dur}."
+        )
+
+
 async def download(
     job: Job,
     out_dir: Path,
@@ -129,14 +138,7 @@ async def download(
     ) as tmp_file:
         temp_filepath = Path(tmp_file.name)
 
-        await download_stream(job.url, temp_filepath)
-
-        recorded_dur = await get_duration(temp_filepath)
-
-        if abs(recorded_dur - job.program.dur) > 1:
-            raise AssertionError(
-                f"Recorded duration {recorded_dur} differs from the program duration {job.program.dur}."
-            )
+        await _download_and_validate_stream(job, temp_filepath)
 
         out_filepath = try_rename_with_candidates(
             temp_filepath, out_filepath_candidates

--- a/radiko_timeshift_recorder/fs_unix.py
+++ b/radiko_timeshift_recorder/fs_unix.py
@@ -1,0 +1,26 @@
+"""Unix filesystem helpers."""
+
+# Permission + setuid/setgid/sticky bits (12 bits), as accepted by chmod(2) on Unix.
+_MAX_MODE = 0o7777
+
+
+def parse_unix_mode_string(value: str) -> int:
+    """
+    Parse a non-empty string of octal digits (e.g. ``644``, ``0755``, ``2775``).
+
+    Rejects values above ``0o7777`` (e.g. ``77777``) so only the usual chmod
+    bit range is accepted.
+    """
+    v = value.strip()
+    if not v:
+        raise ValueError("Mode string is empty.")
+    if not all(c in "01234567" for c in v):
+        raise ValueError(
+            f"Mode must be octal digits only (e.g. 644 or 0755), got {value!r}"
+        )
+    mode = int(v, 8)
+    if mode > _MAX_MODE:
+        raise ValueError(
+            f"Mode must be at most {_MAX_MODE:o} (12 permission bits), got {value!r}"
+        )
+    return mode

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,15 +1,19 @@
 import datetime
 import errno
 from pathlib import Path
+from unittest.mock import AsyncMock
 from zoneinfo import ZoneInfo
 
 import pytest
 from pytest_mock import MockerFixture
 
 from radiko_timeshift_recorder.download import (
+    DEFAULT_OUTPUT_FILE_MODE,
+    download,
     generate_filename_candidates,
     try_rename_with_candidates,
 )
+from radiko_timeshift_recorder.job import Job
 from radiko_timeshift_recorder.radiko import Program
 
 
@@ -181,3 +185,36 @@ def test_try_rename_with_candidates_fail_other_oserror(mocker: MockerFixture) ->
         excinfo.value is permission_error
     )  # Verify that the same exception object is re-raised
     mock_replace.assert_called_once_with(out_filepath_candidates[0])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", [0o600, DEFAULT_OUTPUT_FILE_MODE])
+async def test_download_applies_output_file_mode(
+    tmp_path: Path,
+    sample_job: Job,
+    mocker: MockerFixture,
+    mode: int,
+) -> None:
+    async def fake_download_stream(url: str, out_filepath: Path) -> None:
+        out_filepath.write_bytes(b"x")
+
+    mocker.patch(
+        "radiko_timeshift_recorder.download.download_stream",
+        side_effect=fake_download_stream,
+    )
+    mocker.patch(
+        "radiko_timeshift_recorder.download.get_duration",
+        new_callable=AsyncMock,
+        return_value=float(sample_job.program.dur),
+    )
+
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    await download(sample_job, out_dir, output_file_mode=mode)
+
+    mp4s = list(
+        (out_dir / sample_job.station_id / sample_job.program.title).glob("*.mp4")
+    )
+    assert len(mp4s) == 1
+    assert (mp4s[0].stat().st_mode & 0o7777) == mode

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -218,3 +218,34 @@ async def test_download_applies_output_file_mode(
     )
     assert len(mp4s) == 1
     assert (mp4s[0].stat().st_mode & 0o7777) == mode
+
+
+@pytest.mark.asyncio
+async def test_download_retries_stream_after_transient_failure(
+    tmp_path: Path,
+    sample_job: Job,
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch("asyncio.sleep", new_callable=AsyncMock)
+
+    download_stream_spy = mocker.patch(
+        "radiko_timeshift_recorder.download.download_stream",
+        new_callable=AsyncMock,
+        side_effect=[RuntimeError("transient stream failure"), None],
+    )
+    mocker.patch(
+        "radiko_timeshift_recorder.download.get_duration",
+        new_callable=AsyncMock,
+        return_value=float(sample_job.program.dur),
+    )
+
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    await download(sample_job, out_dir)
+
+    assert download_stream_spy.call_count == 2
+    mp4s = list(
+        (out_dir / sample_job.station_id / sample_job.program.title).glob("*.mp4")
+    )
+    assert len(mp4s) == 1

--- a/tests/test_fs_unix.py
+++ b/tests/test_fs_unix.py
@@ -1,0 +1,28 @@
+import pytest
+
+from radiko_timeshift_recorder.fs_unix import parse_unix_mode_string
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("644", 0o644),
+        ("0644", 0o644),
+        ("755", 0o755),
+        ("2775", 0o2775),
+        ("7777", 0o7777),
+    ],
+)
+def test_parse_unix_mode_string(text: str, expected: int) -> None:
+    assert parse_unix_mode_string(text) == expected
+
+
+def test_parse_unix_mode_string_rejects_python_literal() -> None:
+    with pytest.raises(ValueError, match="octal digits"):
+        parse_unix_mode_string("0o644")
+
+
+@pytest.mark.parametrize("too_large", ["77777", "100000", "777777"])
+def test_parse_unix_mode_string_rejects_too_many_bits(too_large: str) -> None:
+    with pytest.raises(ValueError, match="12 permission bits"):
+        parse_unix_mode_string(too_large)


### PR DESCRIPTION
- Add --output-file-mode to run-server (octal string, default 644).

- Apply os.chmod to the final .mp4 path after rename; expose DEFAULT_OUTPUT_FILE_MODE.

- Add fs_unix.parse_unix_mode_string for CLI validation.

- Add tests for mode parsing and download chmod (mocked stream/duration).

Made-with: Cursor
